### PR TITLE
processing data with cut sucks -- trim first!

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ We will reject your tool if it:
 
 ## What's Included
 
-Coming soon!
+trim: remove trailing and leading whitespace

--- a/trim
+++ b/trim
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# trim whitespace
+#
+
+function trim {
+  awk '{$1=$1};1'
+}
+
+trim


### PR DESCRIPTION
trim is a simple script to remove leading and trailing whitespace. So many UNIX tools add whitespace by default for formatting, when all you want is a column. Current implementation is a simple awk command, but I guess some enterprising individual could rewrite it in pure bash. 

Or C. Or Rust. Yea, let's be that kind of project.